### PR TITLE
setup nix flakes for dev environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /target
+/postgres_data
+/data

--- a/README.md
+++ b/README.md
@@ -21,11 +21,11 @@ The project is organized into three main layers:
 ## Getting Started
 
 ### Prerequisites
-- Rust and Cargo are required to build and run the application(This is provided via nix). You can also install them using [rustup](https://rustup.rs/).
-- PostgreSQL is used as the database for this project.(This is provided via docker compose using nix flakes)
-- Nix flake is used to manage the development environment. You can install it using the instructions [here](https://nixos.org/download.html).
-- Docker is used to manage the database. You can install it using the instructions [here](https://docs.docker.com/get-docker/).
-- Diesel CLI is used to manage the database schema. (This is provided via nix flakes)
+- Rust and Cargo are required to build and run the application (this is provided via Nix). You can also install them globally using [rustup](https://rustup.rs/).
+- PostgreSQL is used as the database for this project (this is provided via docker compose using Nix flakes).
+- Nix flake is used to manage the dependencies in the development environment. You can install it following the instructions [here](https://nixos.org/download.html).
+- Docker is used to manage the database. You can install it following the instructions [here](https://docs.docker.com/get-docker/).
+- Diesel CLI is used to manage the database schema (this is provided via Nix flakes).
 
 1. **Clone the Repository**:
    ```bash
@@ -34,19 +34,24 @@ The project is organized into three main layers:
    ```
 
 2. **Setup the Development Environment**:
-> before running the following command, make sure you have nix-package manager installed on your system. If not, you can install it using the instructions [here](https://nixos.org/download.html).
+> [!IMPORTANT] 
+> Before running the following command, make sure you have nix-package manager installed on your system. If not, you can install it following the instructions provided [here](https://nixos.org/download.html).
+> [!NOTE]  
 > You should configure your nix to use flake by setting your ~/.config/nix/nix.conf file to use flake as follows:
 ```plaintext
 experimental-features = nix-command flakes
 ```
-then run the following command to install the dependencies and setup the development environment in th project directory:
+
+then run the following command to install the dependencies and setup the development environment in the project directory:
    ```bash
     nix develop
    ```
-else you can run the following command to install the dependencies and setup the development environment:
+
+Alternatively, you can run the following command to install the dependencies and setup the development environment:
    ```bash
    nix develop --experimental-features 'nix-command flakes'
    ```
+
 3. **Run the Application**:
    ```bash
    cargo run

--- a/README.md
+++ b/README.md
@@ -21,38 +21,39 @@ The project is organized into three main layers:
 ## Getting Started
 
 ### Prerequisites
+
 - Rust and Cargo are required to build and run the application (this is provided via Nix). You can also install them globally using [rustup](https://rustup.rs/).
 - PostgreSQL is used as the database for this project (this is provided via docker compose using Nix flakes).
 - Nix flake is used to manage the dependencies in the development environment. You can install it following the instructions [here](https://nixos.org/download.html).
 - Docker is used to manage the database. You can install it following the instructions [here](https://docs.docker.com/get-docker/).
 - Diesel CLI is used to manage the database schema (this is provided via Nix flakes).
 
-1. **Clone the Repository**:
+1 **Clone the Repository**:
+
    ```bash
    git clone https://github.com/extheoisah/hxckr-core.git
    cd hxckr-core
    ```
 
-2. **Setup the Development Environment**:
-> [!IMPORTANT] 
+2.**Setup the Development Environment**:
+> [!IMPORTANT]
 > Before running the following command, make sure you have nix-package manager installed on your system. If not, you can install it following the instructions provided [here](https://nixos.org/download.html).
-> [!NOTE]  
-> You should configure your nix to use flake by setting your ~/.config/nix/nix.conf file to use flake as follows:
-```plaintext
-experimental-features = nix-command flakes
-```
+> You should configure your nix to use flake by setting your ~/.config/nix/nix.conf file to use flake as follows: `experimental-features = nix-command flakes`
 
 then run the following command to install the dependencies and setup the development environment in the project directory:
+
    ```bash
     nix develop
    ```
 
 Alternatively, you can run the following command to install the dependencies and setup the development environment:
+
    ```bash
    nix develop --experimental-features 'nix-command flakes'
    ```
 
-3. **Run the Application**:
+3.**Run the Application**:
+
    ```bash
    cargo run
    ```

--- a/README.md
+++ b/README.md
@@ -20,34 +20,37 @@ The project is organized into three main layers:
 
 ## Getting Started
 
-1. **Clone the Repository**:
+### Prerequisites
+- Rust and Cargo are required to build and run the application(This is provided via nix). You can also install them using [rustup](https://rustup.rs/).
+- PostgreSQL is used as the database for this project.(This is provided via docker compose using nix flakes)
+- Nix flake is used to manage the development environment. You can install it using the instructions [here](https://nixos.org/download.html).
+- Docker is used to manage the database. You can install it using the instructions [here](https://docs.docker.com/get-docker/).
+- Diesel CLI is used to manage the database schema. (This is provided via nix flakes)
 
+1. **Clone the Repository**:
    ```bash
    git clone https://github.com/extheoisah/hxckr-core.git
    cd hxckr-core
    ```
 
-2. **Run the Application**:
-
+2. **Setup the Development Environment**:
+> before running the following command, make sure you have nix-package manager installed on your system. If not, you can install it using the instructions [here](https://nixos.org/download.html).
+> You should configure your nix to use flake by setting your ~/.config/nix/nix.conf file to use flake as follows:
+```plaintext
+experimental-features = nix-command flakes
+```
+then run the following command to install the dependencies and setup the development environment in th project directory:
+   ```bash
+    nix develop
+   ```
+else you can run the following command to install the dependencies and setup the development environment:
+   ```bash
+   nix develop --experimental-features 'nix-command flakes'
+   ```
+3. **Run the Application**:
    ```bash
    cargo run
    ```
-
-## Project Structure
-
-```plaintext
-hxckr-core/
-│
-├── src/
-│   ├── app/            # Application Layer
-│   ├── domain/         # Domain Layer
-│   ├── service/        # Infrastructure Layer
-│   ├── main.rs         # Entry point
-│
-├── tests/              # Integration tests
-├── Cargo.toml          # Cargo configuration
-└── README.md           # Project documentation
-```
 
 ## Contributing
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1723991338,
+        "narHash": "sha256-Grh5PF0+gootJfOJFenTTxDTYPidA3V28dqJ/WV7iis=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "8a3354191c0d7144db9756a74755672387b702ba",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,73 @@
+{
+  description = "Hxckr-core development environment";
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system: let
+      pkgs = import nixpkgs { inherit system; };
+    in {
+      devShells.default = pkgs.mkShell {
+        buildInputs = with pkgs; [
+          docker
+          docker-compose
+          rustup
+          soft-serve
+        ];
+
+        shellHook = ''
+          # PostgreSQL setup
+          export POSTGRES_DATA="$PWD/postgres_data"
+          export POSTGRES_HOST="localhost"
+          export POSTGRES_PORT=5432
+          export POSTGRES_USER="my_user"
+          export POSTGRES_PASSWORD="my_password"
+          export POSTGRES_DB="my_database"
+          mkdir -p "$POSTGRES_DATA"
+          docker-compose --file ${pkgs.writeText "docker-compose.yml" ''
+            version: '3'
+            services:
+              postgres:
+                image: postgres:14
+                restart: always
+                environment:
+                  POSTGRES_USER: $POSTGRES_USER
+                  POSTGRES_PASSWORD: $POSTGRES_PASSWORD
+                  POSTGRES_DB: $POSTGRES_DB
+                ports:
+                  - "$POSTGRES_PORT:5432"
+                volumes:
+                  - $POSTGRES_DATA:/var/lib/postgresql/data
+            volumes:
+              postgres:
+          ''} up -d
+
+          # Rust setup
+          echo "Setting up Rust"
+          rustup default stable
+          export PATH="$HOME/.cargo/bin:$PATH"
+
+          # Clean up when shell is exited
+          trap 'docker-compose --file ${pkgs.writeText "docker-compose.yml" ''
+            version: '3'
+            services:
+              postgres:
+                image: postgres:14
+                restart: always
+                environment:
+                  POSTGRES_USER: $POSTGRES_USER
+                  POSTGRES_PASSWORD: $POSTGRES_PASSWORD
+                  POSTGRES_DB: $POSTGRES_DB
+                ports:
+                  - "$POSTGRES_PORT:5432"
+                volumes:
+                  - $POSTGRES_DATA:/var/lib/postgresql/data
+            volumes:
+              postgres:
+          ''} down' EXIT
+        '';
+      };
+    });
+}

--- a/flake.nix
+++ b/flake.nix
@@ -18,19 +18,22 @@
         ];
 
         shellHook = ''
+          # Change the prompt color to blue when in the Nix shell
+          export PS1="\[\033[01;34m\]\u@\h:\w\[\033[00m\]\$ "
+          echo "You are now in the Nix shell with a blue prompt!"
           # PostgreSQL setup
           export POSTGRES_DATA="$PWD/postgres_data"
           export POSTGRES_HOST="localhost"
           export POSTGRES_PORT=5432
-          export POSTGRES_USER="my_user"
-          export POSTGRES_PASSWORD="my_password"
-          export POSTGRES_DB="my_database"
+          export POSTGRES_USER="postgres"
+          export POSTGRES_PASSWORD="postgres"
+          export POSTGRES_DB="postgres"
           mkdir -p "$POSTGRES_DATA"
           docker-compose --file ${pkgs.writeText "docker-compose.yml" ''
             version: '3'
             services:
               postgres:
-                image: postgres:14
+                image: postgres:15-alpine
                 restart: always
                 environment:
                   POSTGRES_USER: $POSTGRES_USER
@@ -54,7 +57,7 @@
             version: '3'
             services:
               postgres:
-                image: postgres:14
+                image: postgres:15-alpine
                 restart: always
                 environment:
                   POSTGRES_USER: $POSTGRES_USER

--- a/flake.nix
+++ b/flake.nix
@@ -8,68 +8,74 @@
   outputs = { self, nixpkgs, flake-utils }:
     flake-utils.lib.eachDefaultSystem (system: let
       pkgs = import nixpkgs { inherit system; };
+
+      # Docker Compose configuration
+      dockerComposeFile = pkgs.writeText "docker-compose.yml" ''
+        services:
+          postgres:
+            container_name: hxckr-core
+            image: postgres:15-alpine
+            restart: always
+            environment:
+              POSTGRES_USER: $POSTGRES_USER
+              POSTGRES_PASSWORD: $POSTGRES_PASSWORD
+              POSTGRES_DB: $POSTGRES_DB
+            ports:
+              - "$POSTGRES_PORT:5432"
+            volumes:
+              - $POSTGRES_DATA:/var/lib/postgresql/data
+        volumes:
+          postgres:
+      '';
+
+      # Function to start and stop the PostgreSQL container
+      startPostgres = ''
+        docker-compose --file ${dockerComposeFile} up -d
+        echo "PostgreSQL development database started"
+      '';
+      stopPostgres = ''
+        docker-compose --file ${dockerComposeFile} down
+      '';
+
     in {
       devShells.default = pkgs.mkShell {
+        name = "hxckr-core";
         buildInputs = with pkgs; [
           docker
           docker-compose
           rustup
           soft-serve
+          diesel-cli
+          openssl
+          pkg-config
         ];
 
         shellHook = ''
           # Change the prompt color to blue when in the Nix shell
           export PS1="\[\033[01;34m\]\u@\h:\w\[\033[00m\]\$ "
-          echo "You are now in the Nix shell with a blue prompt!"
+          echo "You are now in the Nix shell!"
+
           # PostgreSQL setup
           export POSTGRES_DATA="$PWD/postgres_data"
-          export POSTGRES_HOST="localhost"
+          export POSTGRES_HOST="0.0.0.0"
           export POSTGRES_PORT=5432
           export POSTGRES_USER="postgres"
           export POSTGRES_PASSWORD="postgres"
           export POSTGRES_DB="postgres"
           mkdir -p "$POSTGRES_DATA"
-          docker-compose --file ${pkgs.writeText "docker-compose.yml" ''
-            version: '3'
-            services:
-              postgres:
-                image: postgres:15-alpine
-                restart: always
-                environment:
-                  POSTGRES_USER: $POSTGRES_USER
-                  POSTGRES_PASSWORD: $POSTGRES_PASSWORD
-                  POSTGRES_DB: $POSTGRES_DB
-                ports:
-                  - "$POSTGRES_PORT:5432"
-                volumes:
-                  - $POSTGRES_DATA:/var/lib/postgresql/data
-            volumes:
-              postgres:
-          ''} up -d
+
+          ${startPostgres}
 
           # Rust setup
           echo "Setting up Rust"
           rustup default stable
           export PATH="$HOME/.cargo/bin:$PATH"
 
+          # Diesel CLI setup
+          export DATABASE_URL="postgres://$POSTGRES_USER:$POSTGRES_PASSWORD@$POSTGRES_HOST:$POSTGRES_PORT/$POSTGRES_DB"
+
           # Clean up when shell is exited
-          trap 'docker-compose --file ${pkgs.writeText "docker-compose.yml" ''
-            version: '3'
-            services:
-              postgres:
-                image: postgres:15-alpine
-                restart: always
-                environment:
-                  POSTGRES_USER: $POSTGRES_USER
-                  POSTGRES_PASSWORD: $POSTGRES_PASSWORD
-                  POSTGRES_DB: $POSTGRES_DB
-                ports:
-                  - "$POSTGRES_PORT:5432"
-                volumes:
-                  - $POSTGRES_DATA:/var/lib/postgresql/data
-            volumes:
-              postgres:
-          ''} down' EXIT
+          trap '${stopPostgres}' EXIT
         '';
       };
     });


### PR DESCRIPTION
Fix issue #5 

This PR introduce nix flakes for development purpose, which makes it easy to manage dependencies locally and across machine.

## to set up 

- setup nix locally using (https://nixos.org/download/)[https://nixos.org/download/] for system 
- flake is an addition to nix, and you will need to explicitly enable it for your nix env. see guide (https://nixos.wiki/wiki/Flakes)[https://nixos.wiki/wiki/Flakes]
- in the project directory, run `nix develop` to start the project. 
- the resulting will provide the all packages to run the project in shell environment.