### PR TITLE
chore: Added dockerhub publishing

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,40 @@
+name: Docker Publish
+
+on:
+  push:
+    branches: [ "main" ]
+  release:
+    types: [created]
+
+env:
+  DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+  DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+  IMAGE_NAME: ${{ secrets.DOCKERHUB_USERNAME }}/hxckr-core
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ env.DOCKERHUB_USERNAME }}
+          password: ${{ env.DOCKERHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          push: true
+          tags: |
+            ${{ env.IMAGE_NAME }}:latest
+            ${{ env.IMAGE_NAME }}:${{ github.sha }}
+            ${{ env.IMAGE_NAME }}:${{ github.ref_name }}
+          cache-from: type=registry,ref=${{ env.IMAGE_NAME }}:buildcache
+          cache-to: type=registry,ref=${{ env.IMAGE_NAME }}:buildcache,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+# Build stage
+FROM rust:latest as builder
+WORKDIR /usr/src/hxckr-core
+COPY . .
+RUN apt-get update && apt-get install -y libpq-dev
+RUN cargo build --release
+
+# Runtime stage
+FROM debian:bullseye-slim
+RUN apt-get update && apt-get install -y libpq-dev && rm -rf /var/lib/apt/lists/*
+COPY --from=builder /usr/src/hxckr-core/target/release/hxckr-core /usr/local/bin/hxckr-core
+CMD ["hxckr-core"]

--- a/README.md
+++ b/README.md
@@ -62,3 +62,37 @@ If you are running the application for the first time, please follow the instruc
 ## Contributing
 
 Contributions are welcome! Please open an issue or submit a pull request. For more details, please refer to the [CONTRIBUTING.md](CONTRIBUTING.md) file.
+
+## Docker
+
+### Building the Docker Image
+
+To build the Docker image locally:
+
+1. Ensure you have Docker installed on your machine.
+2. Navigate to the project root directory in your terminal.
+3. Build the Docker image:
+   ```
+   docker build -t hxckr-core:local .
+   ```
+
+### Running the Docker Container
+
+To run the Docker container:
+
+```
+docker run -p
+```
+
+## Publishing Docker Images
+
+This project uses GitHub Actions to automatically publish Docker images to DockerHub. If you fork this repository, you'll need to set up the publishing process:
+
+1. Create a DockerHub account if you don't have one.
+2. Create a new repository on DockerHub for your images.
+3. In your GitHub repository settings, add the following secrets:
+   - `DOCKERHUB_USERNAME`: Your DockerHub username
+   - `DOCKERHUB_TOKEN`: A DockerHub access token (create this in your DockerHub account settings)
+4. Update the GitHub Actions workflow file (`.github/workflows/docker-publish.yml`) with your DockerHub repository name.
+
+The workflow will build and push a new Docker image on each push to the main branch and when a new release is created.


### PR DESCRIPTION
# Add Docker support and automated publishing

This PR introduces Docker support to our project and sets up automated Docker image publishing using GitHub Actions. The changes include:

1. Added a `Dockerfile` for building the project image
2. Created a GitHub Actions workflow for automated Docker image publishing
3. Updated the README with Docker-related instructions

## Changes

### Dockerfile

- Added a multi-stage Dockerfile to build and run the application
- Uses Rust's official image for building and Debian Bullseye slim for runtime
- Installs necessary dependencies (libpq-dev) for PostgreSQL support

### GitHub Actions Workflow

- Created `.github/workflows/docker-publish.yml`
- Configures automatic building and publishing of Docker images to DockerHub
- Triggers on pushes to the main branch and new releases
- Uses Docker Buildx for multi-platform support and caching

### README Updates

- Added a "Docker" section with instructions for building and running the Docker image locally
- Included a "Publishing Docker Images" section explaining the automated process and required setup for forks

These changes will streamline our deployment process and make it easier for contributors to run the project in a consistent environment.