### PR TITLE
fix: fixed multiplatform build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update && apt-get install -y libpq-dev
 RUN cargo build --release
 
 # Runtime stage
-FROM debian:bullseye-slim
+FROM debian:bookworm-slim
 RUN apt-get update && apt-get install -y libpq-dev && rm -rf /var/lib/apt/lists/*
 COPY --from=builder /usr/src/hxckr-core/target/release/hxckr-core /usr/local/bin/hxckr-core
 CMD ["hxckr-core"]

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ To build the Docker image locally:
 To run the Docker container:
 
 ```
-docker run -p
+docker run -p 8080:80 -e DATABASE_URL=postgres://real_username:real_password@real_host/real_db hxckr-core:local
 ```
 
 ## Publishing Docker Images


### PR DESCRIPTION
There was a further issue with some dependencies when trying to run the docker container in k8s.  This should fix it.