### PR TITLE
feat: add create repo from git service

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,2 @@
+DATABASE_URL=postgres://postgres:postgres@localhost:5432/postgres
+GIT_SERVICE_URL=http://localhost:8080

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@
 /postgres_data
 /data
 diesel.toml
-.env*
+.env

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,8 +39,8 @@ dependencies = [
  "encoding_rs",
  "flate2",
  "futures-core",
- "h2",
- "http",
+ "h2 0.3.26",
+ "http 0.2.12",
  "httparse",
  "httpdate",
  "itoa",
@@ -76,7 +76,7 @@ checksum = "13d324164c51f63867b57e73ba5936ea151b8a41a1d23d1031eeb9f70d0236f8"
 dependencies = [
  "bytestring",
  "cfg-if",
- "http",
+ "http 0.2.12",
  "regex",
  "regex-lite",
  "serde",
@@ -302,7 +302,7 @@ version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d36fc52c7f6c869915e99412912f22093507da8d9e942ceaf66fe4b7c14422a"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -312,7 +312,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5bf74e1b6e971609db8ca7a9ce79fd5768ab6ae46441c572e46cf596f59e57f8"
 dependencies = [
  "anstyle",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -320,6 +320,12 @@ name = "anyhow"
 version = "1.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10f00e1f6e58a40e807377c75c6a7f97bf9044fab57816f2414e6f5f4499d7b8"
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
@@ -464,6 +470,16 @@ dependencies = [
  "percent-encoding",
  "time",
  "version_check",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -671,6 +687,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
+name = "errno"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6"
+
+[[package]]
 name = "flate2"
 version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -687,12 +719,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
+dependencies = [
+ "futures-core",
 ]
 
 [[package]]
@@ -776,7 +832,26 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-util",
- "http",
+ "http 0.2.12",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "h2"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "524e8ac6999421f49a846c2d4411f337e53497d8ec55d67753beffa43c5d9205"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http 1.1.0",
  "indexmap",
  "slab",
  "tokio",
@@ -814,6 +889,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http 1.1.0",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http 1.1.0",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "httparse"
 version = "1.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -845,11 +954,85 @@ dependencies = [
  "futures-util",
  "log",
  "rand",
+ "reqwest",
  "serde",
  "serde_json",
  "thiserror",
  "tokio",
  "uuid",
+]
+
+[[package]]
+name = "hyper"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50dfd22e0e76d0f662d429a5f80fcaf3855009297eab6a0a9f8543834744ba05"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "h2 0.4.6",
+ "http 1.1.0",
+ "http-body",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08afdbb5c31130e3034af566421053ab03787c640246a446327f550d11bcb333"
+dependencies = [
+ "futures-util",
+ "http 1.1.0",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da62f120a8a37763efb0cf8fdf264b884c7b8b9ac8660b900c8661030c00e6ba"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http 1.1.0",
+ "http-body",
+ "hyper",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -908,6 +1091,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipnet"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "187674a687eed5fe42285b40c6291f9a01517d415fad1c3cbc6a9f778af7fcd4"
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -948,6 +1137,12 @@ name = "libc"
 version = "0.2.158"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
 
 [[package]]
 name = "local-channel"
@@ -1013,7 +1208,24 @@ dependencies = [
  "libc",
  "log",
  "wasi",
- "windows-sys",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "native-tls"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8614eb2c83d59d1c8cc974dd3f920198647674a0a035e1af1fa58707e317466"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
 ]
 
 [[package]]
@@ -1045,6 +1257,50 @@ name = "once_cell"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+
+[[package]]
+name = "openssl"
+version = "0.10.66"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9529f4786b70a3e8c61e11179af17ab6188ad8d0ded78c5529441ed39d4bd9c1"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.103"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f9e8deee91df40a943c71b917e5874b951d32a802526c85721ce3b776c929d6"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "parking_lot"
@@ -1080,6 +1336,26 @@ name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+
+[[package]]
+name = "pin-project"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6bf43b791c5b9e34c3d182969b4abb522f9343702850a2e57f460d00d09b4b3"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -1227,6 +1503,64 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
+name = "reqwest"
+version = "0.12.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8f4955649ef5c38cc7f9e8aa41761d48fb9677197daea9984dc54f56aad5e63"
+dependencies = [
+ "base64",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2 0.4.6",
+ "http 1.1.0",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-tls",
+ "hyper-util",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "native-tls",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls-pemfile",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "system-configuration",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows-registry",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom",
+ "libc",
+ "spin",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1242,10 +1576,72 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "0.38.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8acb788b847c24f28525660c4d7758620a7210875711f79e7f663cc152726811"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2dabaac7466917e566adb06783a81ca48944c6898a1b08b9374106dd671f4c8"
+dependencies = [
+ "once_cell",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "196fe16b00e106300d3e45ecfcb764fa292a535d7326a29a5875c579c7417425"
+dependencies = [
+ "base64",
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0a2ce646f8655401bb81e7927b812614bd5d91dbc968696be50603510fcaf0"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.102.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+
+[[package]]
+name = "schannel"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9aaafd5a2b6e3d657ff009d82fbd630b6bd54dd4eb06f21693925cdf80f9b8b"
+dependencies = [
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "scheduled-thread-pool"
@@ -1261,6 +1657,29 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75da29fe9b9b08fe9d6b22b5b4bcbc75d8db3aa31e639aa56bb62e9d46bfceaf"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "semver"
@@ -1360,14 +1779,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -1378,6 +1809,49 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "sync_wrapper"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04cbcdd0c794ebb0d4cf35e88edd2f7d2c4c3e9a5a6dab322839b321c6a87a64"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1461,7 +1935,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1476,6 +1950,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
+dependencies = [
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1487,6 +1982,33 @@ dependencies = [
  "pin-project-lite",
  "tokio",
 ]
+
+[[package]]
+name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project",
+ "pin-project-lite",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
@@ -1507,6 +2029,12 @@ checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
 dependencies = [
  "once_cell",
 ]
+
+[[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "typenum"
@@ -1534,6 +2062,12 @@ checksum = "a56d1686db2308d901306f92a263857ef59ea39678a5458e7cb17f01415101f5"
 dependencies = [
  "tinyvec",
 ]
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
@@ -1575,6 +2109,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1607,6 +2150,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61e9300f63a621e96ed275155c108eb6f843b6a26d053f122ab69724559dc8ed"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
 name = "wasm-bindgen-macro"
 version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1636,6 +2191,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c62a0a307cb4a311d3a07867860911ca130c3494e8c2719593806c08bc5d0484"
 
 [[package]]
+name = "web-sys"
+version = "0.3.70"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26fdeaafd9bd129f65e7c031593c24d62186301e0c72c8978fa1678be7d532c0"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1645,10 +2210,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-registry"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e400001bb720a623c1c69032f8e3e4cf09984deec740f007dd2b03ec864804b0"
+dependencies = [
+ "windows-result",
+ "windows-strings",
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+dependencies = [
+ "windows-result",
+ "windows-targets",
+]
+
+[[package]]
 name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets",
 ]
@@ -1737,6 +2341,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
 
 [[package]]
 name = "zstd"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,4 @@ futures-util = "0.3.30"
 rand = "0.8.5"
 actix-ws = "0.3.0"
 tokio = { version = "1.35.0", features = ["full", "macros"] }
+reqwest = { version = "0.12.7", features = ["json"] }

--- a/flake.nix
+++ b/flake.nix
@@ -51,10 +51,12 @@
           libiconv
           postgresql
           nodejs-slim_20
-          darwin.apple_sdk.frameworks.SystemConfiguration
-          darwin.apple_sdk.frameworks.Security
-        ];
-
+        ]
+        ++ (if system == "x86_64-darwin" || system == "aarch64-darwin" then [
+          pkgs.darwin.apple_sdk.frameworks.SystemConfiguration
+          pkgs.darwin.apple_sdk.frameworks.Security
+        ] else []);
+          
         shellHook = ''
           # Change the prompt color to blue when in the Nix shell
           export PS1="\[\033[01;34m\]\u@\h:\w\[\033[00m\]\$ "

--- a/flake.nix
+++ b/flake.nix
@@ -50,6 +50,9 @@
           pkg-config
           libiconv
           postgresql
+          nodejs-slim_20
+          darwin.apple_sdk.frameworks.SystemConfiguration
+          darwin.apple_sdk.frameworks.Security
         ];
 
         shellHook = ''
@@ -73,8 +76,7 @@
           rustup default stable
           export PATH="$HOME/.cargo/bin:$PATH"
 
-          # Install node@20 and wscat
-          nix-env -iA nixpkgs.nodejs-slim_20
+          # Install wscat
           npm install -g wscat
 
           # Ensure linker finds libiconv and libpq

--- a/src/app/repo/match_repo.rs
+++ b/src/app/repo/match_repo.rs
@@ -10,7 +10,7 @@ pub async fn match_repo_for_webhook(repo_url: &str) -> Result<Session> {
     let repo = Repository::get_repo(&mut conn, None, None, Some(repo_url.to_string()))
         .context(format!("Failed to find repository with URL: {}", repo_url))?;
     let repo = repo
-        .get(0)
+        .first()
         .ok_or_else(|| anyhow::anyhow!("Repository not found with URL: {}", repo_url))?;
 
     let session = Session::get_by_userid(&mut conn, &repo.user_id).context(format!(

--- a/src/app/routes/challenge.rs
+++ b/src/app/routes/challenge.rs
@@ -33,7 +33,10 @@ async fn create_challenge(
     challenge: Result<web::Json<NewChallenge>, actix_web::Error>,
     pool: web::Data<DbPool>,
 ) -> Result<HttpResponse, Error> {
-    let mut conn = pool.get().expect("couldn't get db connection from pool");
+    let mut conn = pool.get().map_err(|e| {
+        error!("Error getting db connection from pool: {}", e);
+        RepositoryError::DatabaseError(e.to_string())
+    })?;
     let user_id = match req.extensions().get::<SessionInfo>() {
         Some(session_info) => session_info.user_id,
         None => {

--- a/src/app/routes/challenge.rs
+++ b/src/app/routes/challenge.rs
@@ -1,0 +1,142 @@
+use crate::{
+    app::auth::middleware::SessionInfo,
+    service::database::{
+        conn::DbPool,
+        models::{Challenge, User},
+    },
+    shared::{
+        errors::{CreateChallengeError, RepositoryError},
+        primitives::{ChallengeMode, Difficulty, UserRole},
+    },
+};
+use actix_web::{
+    http::StatusCode, web, Error, HttpMessage, HttpRequest, HttpResponse, Result, Scope,
+};
+use log::error;
+use serde_json::json;
+
+pub fn init() -> Scope {
+    web::scope("/challenge").route("", web::post().to(create_challenge))
+}
+
+#[derive(serde::Deserialize, serde::Serialize)]
+struct NewChallenge {
+    title: String,
+    description: String,
+    difficulty: Difficulty,
+    mode: ChallengeMode,
+    repo_url: String,
+}
+
+async fn create_challenge(
+    req: HttpRequest,
+    challenge: Result<web::Json<NewChallenge>, actix_web::Error>,
+    pool: web::Data<DbPool>,
+) -> Result<HttpResponse, Error> {
+    let mut conn = pool.get().expect("couldn't get db connection from pool");
+    let user_id = match req.extensions().get::<SessionInfo>() {
+        Some(session_info) => session_info.user_id,
+        None => {
+            return Ok(HttpResponse::build(StatusCode::UNAUTHORIZED).json(json!({
+                "status": "error",
+                "message": "Unauthorized."
+            })));
+        }
+    };
+    let user = match User::get_user(&mut conn, Some(&user_id), None, None, None) {
+        Ok(user) => user,
+        Err(e) => {
+            error!("Error getting user: {}", e);
+            return Err(Error::from(RepositoryError::BadRequest(
+                "User not found".to_string(),
+            )));
+        }
+    };
+    if user.role != UserRole::Admin.to_str() {
+        return Ok(HttpResponse::build(StatusCode::FORBIDDEN).json(json!({
+            "status": "error",
+            "message": "Forbidden. Only admins can create challenges."
+        })));
+    }
+
+    let challenge = match challenge {
+        Ok(challenge) => {
+            if challenge.title.is_empty()
+                || challenge.description.is_empty()
+                || challenge.repo_url.is_empty()
+            {
+                return Err(Error::from(RepositoryError::BadRequest(
+                    "Empty fields are not allowed".to_string(),
+                )));
+            }
+            // Biased assumption: Given that the starter code repo url is a github url,
+            // we can assume that it must start with https://github.com/
+            if !challenge
+                .repo_url
+                .to_lowercase()
+                .starts_with("https://github.com/")
+            {
+                return Err(Error::from(RepositoryError::BadRequest(
+                    "Repo url must start with 'https://github.com/'".to_string(),
+                )));
+            }
+            // Check if the repo url is valid
+            let client = reqwest::Client::new();
+            match client.get(&challenge.repo_url).send().await {
+                Ok(res) => {
+                    if !res.status().is_success() {
+                        return Err(Error::from(RepositoryError::BadRequest(
+                            "Repo url is not valid".to_string(),
+                        )));
+                    }
+                }
+                Err(_) => {
+                    return Err(Error::from(RepositoryError::BadRequest(
+                        "Repo url is not valid".to_string(),
+                    )));
+                }
+            }
+            challenge
+        }
+        Err(e) => return Err(Error::from(RepositoryError::BadRequest(e.to_string()))),
+    };
+
+    if Challenge::get_challenge(&mut conn, None, Some(&challenge.repo_url.to_lowercase())).is_ok() {
+        return Err(Error::from(RepositoryError::BadRequest(
+            "Challenge with this repo url already exists".to_string(),
+        )));
+    }
+    let new_challenge = Challenge::new(
+        &challenge.title.to_lowercase(),
+        &challenge.description.to_lowercase(),
+        &challenge.repo_url.to_lowercase(),
+        &challenge.difficulty,
+        &challenge.mode,
+    );
+    Ok(Challenge::create(&mut conn, new_challenge)
+        .map(|challenge| {
+            HttpResponse::Ok().json(json!({
+                "status": "success",
+                "message": "Challenge created successfully",
+                "challenge": {
+                    "id": challenge.id,
+                    "title": challenge.title,
+                    "description": challenge.description,
+                    "difficulty": challenge.difficulty,
+                    "mode": challenge.mode,
+                    "repo_url": challenge.repo_url,
+                },
+            }))
+        })
+        .map_err(|e| match e.downcast_ref() {
+            Some(RepositoryError::FailedToCreateChallenge(CreateChallengeError(e))) => {
+                RepositoryError::FailedToCreateChallenge(CreateChallengeError(
+                    diesel::result::Error::DatabaseError(
+                        diesel::result::DatabaseErrorKind::Unknown,
+                        Box::new(e.to_string()),
+                    ),
+                ))
+            }
+            _ => RepositoryError::DatabaseError(e.to_string()),
+        })?)
+}

--- a/src/app/routes/errors.rs
+++ b/src/app/routes/errors.rs
@@ -17,6 +17,7 @@ impl ResponseError for RepositoryError {
     fn status_code(&self) -> StatusCode {
         match self {
             RepositoryError::BadRequest(_) => StatusCode::BAD_REQUEST,
+            RepositoryError::RepositoryAlreadyExists => StatusCode::CONFLICT,
             RepositoryError::UserAlreadyExists => StatusCode::CONFLICT,
             RepositoryError::UserNotFound => StatusCode::NOT_FOUND,
             RepositoryError::FailedToGetUser(_) => StatusCode::NOT_FOUND,

--- a/src/app/routes/errors.rs
+++ b/src/app/routes/errors.rs
@@ -22,6 +22,7 @@ impl ResponseError for RepositoryError {
             RepositoryError::UserNotFound => StatusCode::NOT_FOUND,
             RepositoryError::FailedToGetUser(_) => StatusCode::NOT_FOUND,
             RepositoryError::DatabaseError(_) => StatusCode::INTERNAL_SERVER_ERROR,
+            RepositoryError::ServerConfigurationError(_) => StatusCode::INTERNAL_SERVER_ERROR,
             _ => StatusCode::INTERNAL_SERVER_ERROR,
         }
     }

--- a/src/app/routes/mod.rs
+++ b/src/app/routes/mod.rs
@@ -7,11 +7,12 @@ pub mod signup;
 pub mod users;
 pub mod webhook;
 pub mod repo;
-
+pub mod challenge;
 pub fn init(cfg: &mut web::ServiceConfig) {
     cfg.service(health::init());
     cfg.service(users::init());
     cfg.service(signup::init());
     cfg.service(signin::init());
     cfg.service(repo::init());
+    cfg.service(challenge::init());
 }

--- a/src/app/routes/mod.rs
+++ b/src/app/routes/mod.rs
@@ -6,10 +6,12 @@ pub mod signin;
 pub mod signup;
 pub mod users;
 pub mod webhook;
+pub mod repo;
 
 pub fn init(cfg: &mut web::ServiceConfig) {
     cfg.service(health::init());
     cfg.service(users::init());
     cfg.service(signup::init());
     cfg.service(signin::init());
+    cfg.service(repo::init());
 }

--- a/src/app/routes/repo.rs
+++ b/src/app/routes/repo.rs
@@ -99,14 +99,10 @@ async fn create_repo(
             RepositoryError::BadRequest("Error creating repository".to_string())
         })?;
     let create_repo_response = match response.status() {
-        StatusCode::OK => {
-            let create_repo_response =
-                response.json::<CreateRepoResponse>().await.map_err(|e| {
-                    error!("Error in git service response: {:#?}", e);
-                    RepositoryError::BadRequest("Error decoding repository response".to_string())
-                })?;
-            create_repo_response
-        }
+        StatusCode::OK => response.json::<CreateRepoResponse>().await.map_err(|e| {
+            error!("Error in git service response: {:#?}", e);
+            RepositoryError::BadRequest("Error decoding repository response".to_string())
+        })?,
         StatusCode::CONFLICT => {
             return Err(RepositoryError::RepositoryAlreadyExists);
         }

--- a/src/app/routes/repo.rs
+++ b/src/app/routes/repo.rs
@@ -1,0 +1,135 @@
+use crate::{
+    app::auth::middleware::SessionInfo,
+    service::database::{
+        conn::DbPool,
+        models::{Challenge, Repository, User},
+    },
+    shared::errors::{CreateRepositoryError, RepositoryError},
+};
+use actix_web::{web, HttpMessage, HttpRequest, HttpResponse, Scope};
+use log::error;
+use reqwest::StatusCode;
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct CreateRepoResponse {
+    repo_name: String,
+    repo_url: String,
+}
+
+#[derive(Deserialize)]
+pub struct CreateRepoRequest {
+    repo_url: String,
+}
+
+pub fn init() -> Scope {
+    web::scope("/repo").route("", web::post().to(create_repo))
+}
+
+async fn create_repo(
+    req: HttpRequest,
+    body: Result<web::Json<CreateRepoRequest>, actix_web::Error>,
+    pool: web::Data<DbPool>,
+) -> Result<HttpResponse, RepositoryError> {
+    let repo_url = match body {
+        Ok(body) => body.repo_url.clone(),
+        Err(e) => {
+            error!("Error getting repository url: {}", e);
+            return Err(RepositoryError::BadRequest(
+                "Repository url is required".to_string(),
+            ));
+        }
+    };
+    if repo_url.is_empty() {
+        return Err(RepositoryError::BadRequest(
+            "Repository url is required".to_string(),
+        ));
+    }
+
+    let client = reqwest::Client::new();
+    let git_service_url = std::env::var("GIT_SERVICE_URL").expect("GIT_SERVICE_URL not set");
+    let mut conn = pool.get().expect("couldn't get db connection from pool");
+
+    let user_id = match req.extensions().get::<SessionInfo>() {
+        Some(session_info) => session_info.user_id,
+        None => {
+            return Err(RepositoryError::BadRequest(
+                "User not authenticated".to_string(),
+            ));
+        }
+    };
+    let user = match User::get_user(&mut conn, Some(&user_id), None, None, None) {
+        Ok(user) => user,
+        Err(e) => {
+            error!("Error getting user: {}", e);
+            return Err(RepositoryError::BadRequest("User not found".to_string()));
+        }
+    };
+
+    let challenge = match Challenge::get_challenge(&mut conn, None, Some(&repo_url)) {
+        Ok(challenge) => challenge,
+        Err(e) => {
+            error!("Error getting challenge for repository url: {}", e);
+            return Err(RepositoryError::BadRequest(format!(
+                "repository url starter code {} not found",
+                &repo_url
+            )));
+        }
+    };
+
+    let repo_name = repo_url
+        .split("/")
+        .last()
+        .ok_or(RepositoryError::BadRequest(
+            "Error getting repository name from url".to_string(),
+        ))?;
+    let request_body = json!({
+        "repo_name": format!("{}__{}", user.username, repo_name),
+        "repo_url": &repo_url,
+    });
+    let response = client
+        .post(format!("{}/create_repo", git_service_url))
+        .header("Content-Type", "application/json")
+        .body(request_body.to_string())
+        .send()
+        .await
+        .map_err(|e| {
+            error!("Error creating repository in git service: {:#?}", e);
+            RepositoryError::BadRequest("Error creating repository".to_string())
+        })?;
+    let create_repo_response = match response.status() {
+        StatusCode::OK => {
+            let create_repo_response =
+                response.json::<CreateRepoResponse>().await.map_err(|e| {
+                    error!("Error in git service response: {:#?}", e);
+                    RepositoryError::BadRequest("Error decoding repository response".to_string())
+                })?;
+            create_repo_response
+        }
+        StatusCode::CONFLICT => {
+            return Err(RepositoryError::RepositoryAlreadyExists);
+        }
+        _ => {
+            return Err(RepositoryError::BadRequest(
+                "Error creating repository".to_string(),
+            ));
+        }
+    };
+
+    let repo = Repository::new(&user_id, &challenge.id, &create_repo_response.repo_url);
+    if let Err(e) = Repository::create_repo(&mut conn, repo) {
+        error!("Error creating repository in database: {:#?}", e);
+        return Err(RepositoryError::FailedToCreateRepository(
+            CreateRepositoryError(diesel::result::Error::DatabaseError(
+                diesel::result::DatabaseErrorKind::Unknown,
+                Box::new(e.to_string()),
+            )),
+        ));
+    }
+
+    Ok(HttpResponse::Ok().json(json!({
+        "repo_name": &create_repo_response.repo_name,
+        "repo_url": &create_repo_response.repo_url,
+    })))
+}

--- a/src/app/routes/repo.rs
+++ b/src/app/routes/repo.rs
@@ -79,11 +79,13 @@ async fn create_repo(
     };
 
     let repo_name = repo_url
-        .split("/")
-        .last()
-        .ok_or(RepositoryError::BadRequest(
-            "Error getting repository name from url".to_string(),
-        ))?;
+        .rsplit("/")
+        .next()
+        .and_then(|name| if name.is_empty() { None } else { Some(name) })
+        .ok_or_else(|| {
+            error!("Invalid repository URL format: {}", repo_url);
+            RepositoryError::BadRequest("Invalid repository URL format".to_string())
+        })?;
     let request_body = json!({
         "repo_name": format!("{}__{}", user.username, repo_name),
         "repo_url": &repo_url,

--- a/src/app/routes/signin.rs
+++ b/src/app/routes/signin.rs
@@ -50,7 +50,6 @@ async fn signin(
         user.email.as_deref(),
         user.github_username.as_deref(),
     )
-    .map(|user| user)
     .map_err(|e| match e.downcast_ref() {
         Some(RepositoryError::UserNotFound) => RepositoryError::UserNotFound,
         _ => RepositoryError::FailedToGetUser(GetUserError(diesel::result::Error::DatabaseError(

--- a/src/app/routes/signin.rs
+++ b/src/app/routes/signin.rs
@@ -10,6 +10,7 @@ use crate::{
 };
 use actix_web::{web, HttpResponse, Result, Scope};
 use serde_json::json;
+use log::error;
 
 #[derive(serde::Deserialize)]
 struct UserBody {
@@ -42,7 +43,10 @@ async fn signin(
         Err(e) => return Err(RepositoryError::BadRequest(e.to_string())),
     };
 
-    let mut conn = pool.get().expect("couldn't get db connection from pool");
+    let mut conn = pool.get().map_err(|e| {
+        error!("Error getting db connection from pool: {}", e);
+        RepositoryError::DatabaseError(e.to_string())
+    })?;
     let db_user = User::get_user(
         &mut conn,
         None,

--- a/src/app/routes/signin.rs
+++ b/src/app/routes/signin.rs
@@ -45,6 +45,7 @@ async fn signin(
     let mut conn = pool.get().expect("couldn't get db connection from pool");
     let db_user = User::get_user(
         &mut conn,
+        None,
         user.username.as_deref(),
         user.email.as_deref(),
         user.github_username.as_deref(),

--- a/src/app/routes/users.rs
+++ b/src/app/routes/users.rs
@@ -4,12 +4,14 @@ use crate::{
 };
 use actix_web::{web, HttpResponse, Result, Scope};
 use anyhow::Error as AnyhowError;
+use uuid::Uuid;
 
 #[derive(serde::Deserialize)]
 struct UserQuery {
     username: Option<String>,
     email: Option<String>,
     github_username: Option<String>,
+    id: Option<Uuid>,
 }
 
 pub fn init() -> Scope {
@@ -20,7 +22,11 @@ async fn get_user(
     query: web::Query<UserQuery>,
     pool: web::Data<DbPool>,
 ) -> Result<HttpResponse, RepositoryError> {
-    if query.username.is_none() && query.email.is_none() && query.github_username.is_none() {
+    if query.username.is_none()
+        && query.email.is_none()
+        && query.github_username.is_none()
+        && query.id.is_none()
+    {
         return Err(RepositoryError::BadRequest(
             "No query parameters provided".to_string(),
         ));
@@ -28,7 +34,8 @@ async fn get_user(
 
     let param_count = query.username.is_some() as u8
         + query.email.is_some() as u8
-        + query.github_username.is_some() as u8;
+        + query.github_username.is_some() as u8
+        + query.id.is_some() as u8;
     if param_count != 1 {
         return Err(RepositoryError::BadRequest(
             "Only one of the parameters must be passed".to_string(),
@@ -39,6 +46,7 @@ async fn get_user(
 
     User::get_user(
         &mut connection,
+        query.id.as_ref(),
         query.username.as_deref(),
         query.email.as_deref(),
         query.github_username.as_deref(),

--- a/src/app/routes/users.rs
+++ b/src/app/routes/users.rs
@@ -4,6 +4,7 @@ use crate::{
 };
 use actix_web::{web, HttpResponse, Result, Scope};
 use anyhow::Error as AnyhowError;
+use log::error;
 use uuid::Uuid;
 
 #[derive(serde::Deserialize)]
@@ -42,7 +43,10 @@ async fn get_user(
         ));
     }
 
-    let mut connection = pool.get().expect("couldn't get db connection from pool");
+    let mut connection = pool.get().map_err(|e| {
+        error!("Error getting db connection from pool: {}", e);
+        RepositoryError::DatabaseError(e.to_string())
+    })?;
 
     User::get_user(
         &mut connection,

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,6 +17,12 @@ mod shared;
 async fn main() -> std::io::Result<()> {
     dotenv().ok();
     env_logger::Builder::from_env(Env::default().default_filter_or("debug")).init();
+    if std::env::var("DATABASE_URL").is_err() {
+        panic!("DATABASE_URL is not set");
+    }
+    if std::env::var("GIT_SERVICE_URL").is_err() {
+        panic!("GIT_SERVICE_URL is not set");
+    }
 
     let pool = get_connection_pool();
     let manager_handle = WebSocketManagerHandle::new();

--- a/src/service/database/models.rs
+++ b/src/service/database/models.rs
@@ -18,7 +18,7 @@ pub struct User {
     pub updated_at: NaiveDateTime,
 }
 
-#[derive(Queryable, Insertable, Selectable, Debug)]
+#[derive(Queryable, Insertable, Selectable, Debug, Serialize)]
 #[diesel(table_name = crate::schema::challenges)]
 #[diesel(check_for_backend(diesel::pg::Pg))]
 #[allow(dead_code)]
@@ -33,7 +33,7 @@ pub struct Challenge {
     pub updated_at: NaiveDateTime,
 }
 
-#[derive(Queryable, Insertable, Selectable, Debug)]
+#[derive(Queryable, Insertable, Selectable, Debug, Serialize)]
 #[diesel(table_name = crate::schema::exercises)]
 #[diesel(check_for_backend(diesel::pg::Pg))]
 #[allow(dead_code)]

--- a/src/service/repository/challenge.rs
+++ b/src/service/repository/challenge.rs
@@ -32,10 +32,7 @@ impl Challenge {
         }
     }
 
-    pub fn create_challenge(
-        connection: &mut PgConnection,
-        challenge: Challenge,
-    ) -> Result<Challenge> {
+    pub fn create(connection: &mut PgConnection, challenge: Challenge) -> Result<Challenge> {
         match diesel::insert_into(challenges_table)
             .values(challenge)
             .returning(Challenge::as_returning())
@@ -85,12 +82,8 @@ impl Challenge {
                     .ok_or_else(|| anyhow::anyhow!("Challenge not found"))?;
                 Ok(challenge)
             }
-            (Some(_), Some(_)) => {
-                return Err(anyhow::anyhow!("Cannot provide both id and repo_url").into());
-            }
-            (None, None) => {
-                return Err(anyhow::anyhow!("No input provided").into());
-            }
+            (Some(_), Some(_)) => Err(anyhow::anyhow!("Cannot provide both id and repo_url")),
+            (None, None) => Err(anyhow::anyhow!("No input provided")),
         }
     }
 }

--- a/src/service/repository/challenge.rs
+++ b/src/service/repository/challenge.rs
@@ -17,8 +17,8 @@ impl Challenge {
         title: &str,
         description: &str,
         repo_url: &str,
-        difficulty: Difficulty,
-        mode: ChallengeMode,
+        difficulty: &Difficulty,
+        mode: &ChallengeMode,
     ) -> Self {
         Challenge {
             id: Uuid::new_v4(),

--- a/src/service/repository/challenge.rs
+++ b/src/service/repository/challenge.rs
@@ -3,7 +3,7 @@ use crate::service::database::models::Challenge;
 use crate::shared::errors::GetChallengeError;
 use crate::shared::errors::{
     CreateChallengeError,
-    RepositoryError::{ChallengeNotFound, FailedToCreateChallenge, FailedToGetChallenge},
+    RepositoryError::{FailedToCreateChallenge, FailedToGetChallenge},
 };
 use crate::shared::primitives::{ChallengeMode, Difficulty};
 use crate::shared::utils::string_to_uuid;
@@ -49,24 +49,48 @@ impl Challenge {
         }
     }
 
-    pub fn get_challenge(connection: &mut PgConnection, id: String) -> Result<Option<Challenge>> {
-        let uuid = string_to_uuid(&id).map_err(|e| {
-            error!("Error parsing UUID: {}", e);
-            anyhow::anyhow!("Challenge ID is not valid")
-        })?;
+    pub fn get_challenge(
+        connection: &mut PgConnection,
+        id: Option<String>,
+        repo_url: Option<&str>,
+    ) -> Result<Challenge> {
+        use crate::schema::challenges::dsl::repo_url as repo_url_col;
 
-        let challenge = challenges_table
-            .find(uuid)
-            .first::<Challenge>(connection)
-            .optional()
-            .map_err(|e| {
-                error!("Error getting challenge: {}", e);
-                FailedToGetChallenge(GetChallengeError(e))
-            })?;
-
-        if challenge.is_none() {
-            return Err(ChallengeNotFound.into());
+        match (id, repo_url) {
+            (Some(id), None) => {
+                let uuid = string_to_uuid(&id).map_err(|e| {
+                    error!("Error parsing UUID: {}", e);
+                    anyhow::anyhow!("Challenge ID is not valid")
+                })?;
+                let challenge = challenges_table
+                    .find(uuid)
+                    .first::<Challenge>(connection)
+                    .optional()
+                    .map_err(|e| {
+                        error!("Error getting challenge: {}", e);
+                        FailedToGetChallenge(GetChallengeError(e))
+                    })?
+                    .ok_or_else(|| anyhow::anyhow!("Challenge not found"))?;
+                Ok(challenge)
+            }
+            (None, Some(repo_url)) => {
+                let challenge = challenges_table
+                    .filter(repo_url_col.eq(repo_url))
+                    .first::<Challenge>(connection)
+                    .optional()
+                    .map_err(|e| {
+                        error!("Error getting challenge: {}", e);
+                        FailedToGetChallenge(GetChallengeError(e))
+                    })?
+                    .ok_or_else(|| anyhow::anyhow!("Challenge not found"))?;
+                Ok(challenge)
+            }
+            (Some(_), Some(_)) => {
+                return Err(anyhow::anyhow!("Cannot provide both id and repo_url").into());
+            }
+            (None, None) => {
+                return Err(anyhow::anyhow!("No input provided").into());
+            }
         }
-        Ok(challenge)
     }
 }

--- a/src/service/repository/repo.rs
+++ b/src/service/repository/repo.rs
@@ -10,11 +10,11 @@ use log::error;
 use uuid::Uuid;
 
 impl Repository {
-    pub fn new(user_id: &str, challenge_id: &str, repo_url: &str) -> Self {
+    pub fn new(user_id: &Uuid, challenge_id: &Uuid, repo_url: &str) -> Self {
         Repository {
             id: Uuid::new_v4(),
-            user_id: string_to_uuid(user_id).unwrap(),
-            challenge_id: string_to_uuid(challenge_id).unwrap(),
+            user_id: user_id.to_owned(),
+            challenge_id: challenge_id.to_owned(),
             repo_url: repo_url.to_string(),
             created_at: chrono::Utc::now().naive_utc(),
             updated_at: chrono::Utc::now().naive_utc(),

--- a/src/service/repository/users.rs
+++ b/src/service/repository/users.rs
@@ -118,15 +118,10 @@ impl User {
                     .ok_or_else(|| anyhow::anyhow!("User not found"))?;
                 Ok(user)
             }
-            (Some(_), Some(_), Some(_), Some(_)) => {
-                return Err(anyhow::anyhow!(
-                    "Cannot provide both id and username, email, github_username"
-                )
-                .into());
-            }
-            _ => {
-                return Err(anyhow::anyhow!("No input provided").into());
-            }
+            (Some(_), Some(_), Some(_), Some(_)) => Err(anyhow::anyhow!(
+                "Cannot provide both id and username, email, github_username"
+            )),
+            _ => Err(anyhow::anyhow!("No input provided")),
         }
     }
 }

--- a/src/service/repository/users.rs
+++ b/src/service/repository/users.rs
@@ -69,6 +69,17 @@ impl User {
             email as email_col, github_username as github_username_col, username as username_col,
         };
 
+        let param_count = user_id.is_some() as u8
+            + username.is_some() as u8
+            + email.is_some() as u8
+            + github_username.is_some() as u8;
+
+        if param_count != 1 {
+            return Err(anyhow::anyhow!(
+                "Multiple parameters are not allowed. Please provide only one parameter."
+            ));
+        }
+
         match (user_id, username, email, github_username) {
             (Some(user_id), None, None, None) => {
                 let user = users::table
@@ -118,9 +129,6 @@ impl User {
                     .ok_or_else(|| anyhow::anyhow!("User not found"))?;
                 Ok(user)
             }
-            (Some(_), Some(_), Some(_), Some(_)) => Err(anyhow::anyhow!(
-                "Cannot provide both id and username, email, github_username"
-            )),
             _ => Err(anyhow::anyhow!("No input provided")),
         }
     }

--- a/src/shared/errors.rs
+++ b/src/shared/errors.rs
@@ -2,6 +2,8 @@ pub use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum RepositoryError {
+    #[error("Server configuration error: {0}")]
+    ServerConfigurationError(String),
     #[error("Bad request: {0}")]
     BadRequest(String),
     #[error("{0}")]

--- a/src/shared/errors.rs
+++ b/src/shared/errors.rs
@@ -32,6 +32,8 @@ pub enum RepositoryError {
     FailedToGetProgress(#[from] GetProgressError),
     #[error("Failed to update progress")]
     FailedToUpdateProgress(#[from] UpdateProgressError),
+    #[error("Repository already exists")]
+    RepositoryAlreadyExists,
     #[error("Failed to create repository")]
     FailedToCreateRepository(#[from] CreateRepositoryError),
     #[error("Failed to get repository")]

--- a/src/shared/primitives.rs
+++ b/src/shared/primitives.rs
@@ -1,3 +1,6 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize)]
 pub enum Difficulty {
     Easy,
     Medium,
@@ -23,6 +26,7 @@ impl Difficulty {
     }
 }
 
+#[derive(Debug, Serialize, Deserialize)]
 pub enum ChallengeMode {
     FunctionalTest,
     Project,


### PR DESCRIPTION
This pr connects the git service to the backend server. It allows a user to create a repo from the git service and returns the repo URL to the client. 
This pr also adds a new endpoint that allows admins to add challenges (courses) to the database. The repository URL field of the challenge is the starter code URL hosted on GitHub. This URL is needed to create a new repository for the user. The git service creates the user repo off of the starter code provided which in this case is mapped to Github repository.