### PR TITLE
fix: server should be exposed on external IP

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -56,7 +56,7 @@ async fn main() -> std::io::Result<()> {
                     .route(web::get().to(websocket_handler)),
             )
     })
-    .bind("127.0.0.1:4925")?
+    .bind("0.0.0.0:4925")?
     .run()
     .await
 }


### PR DESCRIPTION
Right now the server is exposed in localhost which means in docker we can't connect to the server externally.