### PR TITLE
feat(refactor): add cors and separate websocket and http authentication logic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,6 +20,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "actix-cors"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9e772b3bcafe335042b5db010ab7c09013dad6eac4915c91d8d50902769f331"
+dependencies = [
+ "actix-utils",
+ "actix-web",
+ "derive_more",
+ "futures-util",
+ "log",
+ "once_cell",
+ "smallvec",
+]
+
+[[package]]
 name = "actix-http"
 version = "3.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1461,6 +1476,7 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 name = "hxckr-core"
 version = "0.1.0"
 dependencies = [
+ "actix-cors",
  "actix-web",
  "actix-ws",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,3 +21,4 @@ actix-ws = "0.3.0"
 tokio = { version = "1.35.0", features = ["full", "macros"] }
 reqwest = { version = "0.12.7", features = ["json"] }
 lapin = "2.1.0"
+actix-cors = "0.7.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+use actix_cors::Cors;
 use actix_web::{middleware::Logger, web, App, HttpServer};
 use app::{
     auth::middleware::AuthMiddleware,
@@ -41,20 +42,18 @@ async fn main() -> std::io::Result<()> {
     });
 
     HttpServer::new(move || {
+        let cors = Cors::default()
+            .allow_any_origin()
+            .allow_any_method()
+            .allow_any_header();
         App::new()
             .app_data(web::Data::new(pool.clone()))
             .app_data(web::Data::new(manager_handle.clone()))
             .wrap(Logger::default())
-            .service(
-                web::scope("/api")
-                    .wrap(AuthMiddleware)
-                    .configure(routes::init),
-            )
-            .service(
-                web::resource("/ws")
-                    .wrap(AuthMiddleware)
-                    .route(web::get().to(websocket_handler)),
-            )
+            .wrap(AuthMiddleware)
+            .wrap(cors)
+            .service(web::scope("/api").configure(routes::init))
+            .service(web::resource("/ws").route(web::get().to(websocket_handler)))
     })
     .bind("0.0.0.0:4925")?
     .run()

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,6 +31,8 @@ async fn main() -> std::io::Result<()> {
         panic!("RABBITMQ_QUEUE_NAME is not set");
     }
 
+    let connection_url =
+        std::env::var("CONNECTION_URL").unwrap_or_else(|_| "127.0.0.1:4925".to_string());
     let pool = get_connection_pool();
     let manager_handle = WebSocketManagerHandle::new();
     let manager_handle_clone = manager_handle.clone();
@@ -55,7 +57,7 @@ async fn main() -> std::io::Result<()> {
             .service(web::scope("/api").configure(routes::init))
             .service(web::resource("/ws").route(web::get().to(websocket_handler)))
     })
-    .bind("0.0.0.0:4925")?
+    .bind(&connection_url)?
     .run()
     .await
 }


### PR DESCRIPTION
This PR separates the authentication logic for the websocket and http/https connection.

This is necessary because we're using the same middleware for both HTTP and WebSocket requests but websocket connection from web-browsers have a limitation on the request headers.
The WebSocket API does not support custom headers during the handshake.
This is a browser security limitation.
So, we need to get the session token from the query params for websocket requests