### PR TITLE
Optimize CI/CD: Implement Nix-based dev builds

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,8 +1,8 @@
-name: Docker Publish
+name: Docker Build and Publish
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
   release:
     types: [created]
 
@@ -13,59 +13,44 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  build-and-push:
+  build-and-push-dev:
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      - name: Install Rust
-        uses: actions-rs/toolchain@v1
+      - name: Install Nix
+        uses: cachix/install-nix-action@v20
         with:
-          profile: minimal
-          toolchain: stable
+          nix_path: nixpkgs=channel:nixos-unstable
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+            accept-flake-config = true
+            keep-outputs = true
+            keep-derivations = true
 
-      - name: Cache cargo registry
+      - name: Setup Nix caching
         uses: actions/cache@v3
         with:
           path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+            ~/.cache/nix
+          key: ${{ runner.os }}-nix-${{ hashFiles('**/docker-image.nix', '**/Cargo.lock') }}
           restore-keys: |
-            ${{ runner.os }}-cargo-
+            ${{ runner.os }}-nix-
 
-      - name: Install cargo-chef
-        uses: actions-rs/cargo@v1
-        with:
-          command: install
-          args: cargo-chef
+      - name: Build with Nix
+        run: |
+          nix-build build-image.nix
+          docker load < result
 
-      - name: Prepare recipe
-        run: cargo chef prepare --recipe-path recipe.json
-
-      - name: Cache dependencies
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-chef-${{ hashFiles('**/recipe.json') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-chef-
-
-      - name: Build dependencies
-        run: cargo chef cook --release --recipe-path recipe.json
-
-      - name: Build project
-        run: cargo build --release --all-features
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-        with:
-          install: true
+      - name: Verify image contents
+        run: |
+          docker run --rm hxckr-core:latest ls -l /app
+          docker run --rm hxckr-core:latest ls -l /app/migrations
+          docker run --rm hxckr-core:latest cat /app/entrypoint.sh
+          docker run --rm hxckr-core:latest which diesel
+          docker run --rm hxckr-core:latest diesel --version
 
       - name: Login to DockerHub
         uses: docker/login-action@v2
@@ -73,22 +58,45 @@ jobs:
           username: ${{ env.DOCKERHUB_USERNAME }}
           password: ${{ env.DOCKERHUB_TOKEN }}
 
-      - name: Build and push Docker image (Development)
-        if: github.event_name == 'push'
-        uses: docker/build-push-action@v4
-        with:
-          context: .
-          file: Dockerfile.dev
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: |
-            ${{ env.IMAGE_NAME }}:dev
-            ${{ env.IMAGE_NAME }}:${{ github.sha }}
-          cache-from: type=registry,ref=${{ env.IMAGE_NAME }}:buildcache
-          cache-to: type=registry,ref=${{ env.IMAGE_NAME }}:buildcache,mode=max
+      - name: Push Docker image
+        run: |
+          docker tag hxckr-core:latest ${{ env.IMAGE_NAME }}:dev
+          docker tag hxckr-core:latest ${{ env.IMAGE_NAME }}:${{ github.sha }}
+          docker push ${{ env.IMAGE_NAME }}:dev
+          docker push ${{ env.IMAGE_NAME }}:${{ github.sha }}
 
-      - name: Build and push Docker image (Production)
-        if: github.event_name == 'release'
+      - name: Print image size and details
+        run: |
+          docker image ls ${{ env.IMAGE_NAME }}:dev
+          docker history ${{ env.IMAGE_NAME }}:dev
+
+  build-and-push-prod:
+    if: github.event_name == 'release'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Setup Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+
+      - name: Build project
+        run: |
+          cargo install cargo-chef
+          cargo chef prepare --recipe-path recipe.json
+          cargo chef cook --release --recipe-path recipe.json
+          cargo build --release --all-features
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ env.DOCKERHUB_USERNAME }}
+          password: ${{ env.DOCKERHUB_TOKEN }}
+
+      - name: Build and push Docker image
         uses: docker/build-push-action@v4
         with:
           context: .
@@ -101,8 +109,7 @@ jobs:
           cache-from: type=registry,ref=${{ env.IMAGE_NAME }}:buildcache
           cache-to: type=registry,ref=${{ env.IMAGE_NAME }}:buildcache,mode=max
 
-      - name: Run migrations (Production)
-        if: github.event_name == 'release'
+      - name: Run migrations
         env:
           DATABASE_URL: ${{ secrets.PRODUCTION_DATABASE_URL }}
         run: |
@@ -110,3 +117,8 @@ jobs:
             -e DATABASE_URL \
             ${{ env.IMAGE_NAME }}:${{ github.ref_name }} \
             diesel migration run
+
+      - name: Print image size and details
+        run: |
+          docker image ls ${{ env.IMAGE_NAME }}:${{ github.ref_name }}
+          docker history ${{ env.IMAGE_NAME }}:${{ github.ref_name }}

--- a/build-image.nix
+++ b/build-image.nix
@@ -1,0 +1,81 @@
+{ pkgs ? import <nixpkgs> {} }:
+
+let
+  rustOverlay = import (builtins.fetchTarball "https://github.com/oxalica/rust-overlay/archive/master.tar.gz");
+  pkgs = import <nixpkgs> { overlays = [ rustOverlay ]; };
+  rust = pkgs.rust-bin.stable."1.80.0".default;
+
+  hxckr-core = pkgs.rustPlatform.buildRustPackage {
+    pname = "hxckr-core";
+    version = "0.1.0";
+    src = ./.;
+    cargoLock.lockFile = ./Cargo.lock;
+
+    nativeBuildInputs = [ pkgs.pkg-config ];
+    buildInputs = [ pkgs.openssl pkgs.postgresql ];
+
+    doCheck = false;
+
+    # Optimize the build
+    RUSTFLAGS = "-C target-cpu=native -C opt-level=3";
+    CARGO_PROFILE_RELEASE_LTO = "thin";
+    CARGO_PROFILE_RELEASE_CODEGEN_UNITS = "16";
+    CARGO_PROFILE_RELEASE_OPT_LEVEL = "3";
+    CARGO_PROFILE_RELEASE_PANIC = "abort";
+    CARGO_PROFILE_RELEASE_INCREMENTAL = "false";
+    CARGO_PROFILE_RELEASE_DEBUG = "0";
+
+    # Strip debug symbols
+    stripAllList = [ "bin" ];
+
+    # Use all available cores
+    NIX_BUILD_CORES = 0;
+    preBuild = ''
+      export CARGO_BUILD_JOBS=$NIX_BUILD_CORES
+    '';
+  };
+
+  entrypoint-script = ./entrypoint.dev.sh;
+
+in
+pkgs.dockerTools.buildLayeredImage {
+  name = "hxckr-core";
+  tag = "latest";
+  created = "now";
+
+  contents = [
+    hxckr-core
+    pkgs.diesel-cli
+    pkgs.bash
+    pkgs.coreutils
+    pkgs.findutils
+    pkgs.openssl
+    pkgs.postgresql.lib
+    pkgs.cacert
+    pkgs.libiconv
+  ];
+
+  extraCommands = ''
+    mkdir -p app/migrations
+    cp -r ${./migrations}/* app/migrations/
+    cp ${entrypoint-script} app/entrypoint.sh
+    chmod +x app/entrypoint.sh
+  '';
+
+  config = {
+    Cmd = [ "/app/entrypoint.sh" ];
+    Env = [
+      "SSL_CERT_FILE=${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt"
+      "PATH=/bin:${hxckr-core}/bin:${pkgs.diesel-cli}/bin:${pkgs.findutils}/bin"
+      "LD_LIBRARY_PATH=${pkgs.lib.makeLibraryPath [
+        pkgs.openssl
+        pkgs.postgresql.lib
+        pkgs.libiconv
+      ]}"
+    ];
+    WorkingDir = "/app";
+    ExposedPorts = {
+      "4925/tcp" = {};
+    };
+  };
+}


### PR DESCRIPTION
## Motivation for Changes
This PR addressed an issue relating to:

1. Slow development builds
2. Clear separation between dev and prod workflows


## Changes Proposed
To address these issues, we've refactored our Docker Build and Publish workflow:

1. Separated dev and prod into distinct jobs: `build-and-push-dev` and `build-and-push-prod`.
2. Development builds (on push to main):
   - Now use Nix for consistent, reproducible builds
   - Implement proper Nix caching to speed up subsequent builds
   - Added steps to verify image contents before pushing
   - Push with both 'dev' and commit SHA tags for better traceability
3. Production builds (on release):
   - Still maintained existing Rust/Cargo (subject to change)
4. Added image size and details printing for both processes.

## Expected Benefits
- Faster, more consistent development builds
- Clearer distinction between dev and prod processes
- Better traceability with additional tagging for dev builds
- Easier maintenance and future optimizations of each build process

## Testing Done
- Verified successful workflow runs on push to main
- Checked Docker images build and push correctly in for dev

## Next Steps
- Monitor build times and stability over the next few releases
- Collect team feedback on the new Nix-based dev process
- Consider gradually introducing Nix to the production build if dev process proves beneficial

Please review these changes and provide any feedback or concerns.