### PR TITLE
feat: add "get-progress" endpoint

### DIFF
--- a/src/app/auth/middleware.rs
+++ b/src/app/auth/middleware.rs
@@ -61,6 +61,7 @@ where
         if req.path() == "/api/sign-in"
             || req.path() == "/api/sign-up"
             || req.path() == "/api/health"
+            || req.path() == "/api/progress"
         {
             let fut = self.service.call(req);
             return Box::pin(async move {

--- a/src/app/routes/errors.rs
+++ b/src/app/routes/errors.rs
@@ -23,6 +23,7 @@ impl ResponseError for RepositoryError {
             RepositoryError::FailedToGetUser(_) => StatusCode::NOT_FOUND,
             RepositoryError::DatabaseError(_) => StatusCode::INTERNAL_SERVER_ERROR,
             RepositoryError::ServerConfigurationError(_) => StatusCode::INTERNAL_SERVER_ERROR,
+            RepositoryError::NotFound(_) => StatusCode::NOT_FOUND,
             _ => StatusCode::INTERNAL_SERVER_ERROR,
         }
     }

--- a/src/app/routes/mod.rs
+++ b/src/app/routes/mod.rs
@@ -7,6 +7,8 @@ pub mod signup;
 pub mod users;
 pub mod repo;
 pub mod challenge;
+pub mod progress;
+
 pub fn init(cfg: &mut web::ServiceConfig) {
     cfg.service(health::init());
     cfg.service(users::init());
@@ -14,4 +16,5 @@ pub fn init(cfg: &mut web::ServiceConfig) {
     cfg.service(signin::init());
     cfg.service(repo::init());
     cfg.service(challenge::init());
+    cfg.service(progress::init());
 }

--- a/src/app/routes/progress.rs
+++ b/src/app/routes/progress.rs
@@ -1,0 +1,54 @@
+use crate::{
+    service::database::{
+        conn::DbPool,
+        models::{Progress, Repository},
+    },
+    shared::errors::RepositoryError,
+};
+use actix_web::{web, HttpResponse, Result, Scope};
+use log::error;
+
+pub fn init() -> Scope {
+    web::scope("/progress").route("", web::get().to(get_progress))
+}
+
+#[derive(serde::Deserialize)]
+struct ProgressQuery {
+    repo_url: String,
+}
+
+async fn get_progress(
+    query: Result<web::Query<ProgressQuery>, actix_web::Error>,
+    pool: web::Data<DbPool>,
+) -> Result<HttpResponse, RepositoryError> {
+    let query = match query {
+        Ok(query) => query,
+        Err(_) => {
+            return Err(RepositoryError::BadRequest(String::from(
+                "Invalid query parameters. repo_url is required",
+            )));
+        }
+    };
+
+    let mut conn = pool.get().map_err(|e| {
+        error!("Error getting db connection from pool: {}", e);
+        RepositoryError::DatabaseError(e.to_string())
+    })?;
+
+    let repo =
+        Repository::get_repo(&mut conn, None, None, Some(&query.repo_url), None).map_err(|e| {
+            error!("Error getting repository: {}", e);
+            RepositoryError::NotFound(e.to_string())
+        })?;
+
+    let repo = repo.first().ok_or_else(|| {
+        RepositoryError::NotFound(format!("Repository not found with URL: {}", query.repo_url))
+    })?;
+
+    let progress =
+        Progress::get_progress(&mut conn, None, None, Some(repo.challenge_id)).map_err(|e| {
+            error!("Error getting progress: {}", e);
+            RepositoryError::DatabaseError(e.to_string())
+        })?;
+    Ok(HttpResponse::Ok().json(progress))
+}

--- a/src/service/database/models.rs
+++ b/src/service/database/models.rs
@@ -49,7 +49,7 @@ pub struct Exercise {
     pub status: String,
 }
 
-#[derive(Queryable, Insertable, Selectable, Debug)]
+#[derive(Queryable, Insertable, Selectable, Debug, Serialize)]
 #[diesel(table_name = crate::schema::progress)]
 #[diesel(check_for_backend(diesel::pg::Pg))]
 #[allow(dead_code)]

--- a/src/service/repository/progress.rs
+++ b/src/service/repository/progress.rs
@@ -10,16 +10,22 @@ use crate::shared::utils::string_to_uuid;
 use anyhow::Result;
 use diesel::prelude::*;
 use log::error;
+use serde_json::Value;
 use uuid::Uuid;
 
 impl Progress {
-    pub fn new(user_id: &str, challenge_id: &str, status: Status) -> Self {
+    pub fn new(
+        user_id: &Uuid,
+        challenge_id: &Uuid,
+        status: Status,
+        progress_details: Option<Value>,
+    ) -> Self {
         Progress {
             id: Uuid::new_v4(),
-            user_id: string_to_uuid(user_id).unwrap(),
-            challenge_id: string_to_uuid(challenge_id).unwrap(),
+            user_id: user_id.clone(),
+            challenge_id: challenge_id.clone(),
             status: status.to_str().to_string(),
-            progress_details: None,
+            progress_details,
             created_at: chrono::Utc::now().naive_utc(),
             updated_at: chrono::Utc::now().naive_utc(),
         }

--- a/src/service/repository/progress.rs
+++ b/src/service/repository/progress.rs
@@ -61,9 +61,9 @@ impl Progress {
 
     pub fn get_progress(
         connection: &mut PgConnection,
-        id: Option<String>,
-        user_id: Option<String>,
-        challenge_id: Option<String>,
+        id: Option<Uuid>,
+        user_id: Option<Uuid>,
+        challenge_id: Option<Uuid>,
     ) -> Result<Vec<Progress>> {
         use crate::schema::progress::dsl::{
             challenge_id as challenge_id_col, user_id as user_id_col,
@@ -71,12 +71,8 @@ impl Progress {
 
         match (id, user_id, challenge_id) {
             (Some(id), None, None) => {
-                let id_uuid = string_to_uuid(&id).map_err(|e| {
-                    error!("Error parsing UUID: {}", e);
-                    anyhow::anyhow!("Progress ID is not valid")
-                })?;
                 let progress = progress_table
-                    .find(id_uuid)
+                    .find(id)
                     .first::<Progress>(connection)
                     .optional()
                     .map_err(|e| {
@@ -87,12 +83,8 @@ impl Progress {
                 Ok(vec![progress])
             }
             (None, Some(user_id), None) => {
-                let user_id_uuid = string_to_uuid(&user_id).map_err(|e| {
-                    error!("Error parsing UUID: {}", e);
-                    anyhow::anyhow!("User ID is not valid")
-                })?;
                 let progress = progress_table
-                    .filter(user_id_col.eq(user_id_uuid))
+                    .filter(user_id_col.eq(user_id))
                     .load::<Progress>(connection)
                     .map_err(|e| {
                         error!("Error getting progress: {}", e);
@@ -107,12 +99,8 @@ impl Progress {
                 Ok(progress)
             }
             (None, None, Some(challenge_id)) => {
-                let challenge_id_uuid = string_to_uuid(&challenge_id).map_err(|e| {
-                    error!("Error parsing UUID: {}", e);
-                    anyhow::anyhow!("Challenge ID is not valid")
-                })?;
                 let progress = progress_table
-                    .filter(challenge_id_col.eq(challenge_id_uuid))
+                    .filter(challenge_id_col.eq(challenge_id))
                     .load::<Progress>(connection)
                     .map_err(|e| {
                         error!("Error getting progress: {}", e);


### PR DESCRIPTION
This PR adds a new endpoint to allow users to get progress associated with a challenge. The endpoint accepts a repo_url query which returns the progress details of a user for that repository and challenge.
This PR also ensures that whenever a new repository is created, a new progress is created for that repository so as to allow tracking of the repository progression linked to the respective challenge.

Sample response:

```json
{
    "id": "c2c63e02-ebf6-4321-b766-83b947703210",
    "user_id": "ac02c63b-ab39-4248-976f-1e2e415a8574",
    "challenge_id": "0d420322-7d8a-4fbd-9a78-6636da0f3ec5",
    "status": "not_started",
    "progress_details": {
        "current_step": 1
    },
    "created_at": "2024-10-18T12:03:16.007668",
    "updated_at": "2024-10-18T12:03:16.007668"
}
```