### PR TITLE
feat: get repo with params

### DIFF
--- a/src/app/routes/repo.rs
+++ b/src/app/routes/repo.rs
@@ -6,7 +6,7 @@ use crate::{
     },
     shared::{
         errors::{CreateProgressError, CreateRepositoryError, RepositoryError},
-        primitives::Status,
+        primitives::{PaginationParams, Status},
     },
 };
 use actix_web::{web, HttpMessage, HttpRequest, HttpResponse, Scope};
@@ -33,6 +33,8 @@ pub struct CreateRepoRequest {
 pub struct GetRepoQuery {
     repo_url: Option<String>,
     soft_serve_url: Option<String>,
+    per_page: Option<i64>,
+    page: Option<i64>,
 }
 
 pub fn init() -> Scope {
@@ -240,11 +242,17 @@ async fn get_repo(
         }
     };
 
+    let pagination = PaginationParams {
+        page: query.page,
+        per_page: query.per_page,
+    };
+
     let repositories = Repository::get_repo_with_relations(
         &mut conn,
         &user_id,
         query.repo_url.as_deref(),
         query.soft_serve_url.as_deref(),
+        &pagination,
     )
     .map_err(|e| {
         error!("Error fetching repositories: {}", e);

--- a/src/app/routes/repo.rs
+++ b/src/app/routes/repo.rs
@@ -29,10 +29,11 @@ pub struct CreateRepoRequest {
     repo_url: String,
 }
 
-#[derive(Deserialize)]
+#[derive(Serialize, Deserialize)]
 pub struct GetRepoQuery {
     repo_url: Option<String>,
     soft_serve_url: Option<String>,
+    status: Option<Status>,
     per_page: Option<i64>,
     page: Option<i64>,
 }
@@ -222,7 +223,7 @@ async fn get_repo(
     query: web::Query<GetRepoQuery>,
     pool: web::Data<DbPool>,
 ) -> Result<HttpResponse, RepositoryError> {
-    if query.repo_url.is_some() && query.soft_serve_url.is_some() {
+    if query.repo_url.is_some() && query.soft_serve_url.is_some() && query.status.is_some() {
         return Err(RepositoryError::BadRequest(
             "Multiple parameters are not allowed. Please provide only one parameter.".to_string(),
         ));
@@ -252,6 +253,7 @@ async fn get_repo(
         &user_id,
         query.repo_url.as_deref(),
         query.soft_serve_url.as_deref(),
+        query.status.as_ref(),
         &pagination,
     )
     .map_err(|e| {

--- a/src/service/database/models.rs
+++ b/src/service/database/models.rs
@@ -64,7 +64,7 @@ pub struct Progress {
     pub updated_at: NaiveDateTime,
 }
 
-#[derive(Queryable, Insertable, Selectable, Debug, Clone)]
+#[derive(Queryable, Insertable, Selectable, Debug, Clone, Serialize)]
 #[diesel(table_name = crate::schema::repositories)]
 #[diesel(check_for_backend(diesel::pg::Pg))]
 #[allow(dead_code)]
@@ -169,5 +169,39 @@ pub struct NewUserBadge {
     pub user_id: Uuid,
     pub badge_id: i32,
     pub awarded_at: NaiveDateTime,
+    pub updated_at: NaiveDateTime,
+}
+
+#[derive(Debug, Queryable, Serialize)]
+pub struct RepositoryWithRelations {
+    pub id: Uuid,
+    pub user_id: Uuid,
+    pub challenge_id: Uuid,
+    pub repo_url: String,
+    pub soft_serve_url: String,
+    pub created_at: NaiveDateTime,
+    pub updated_at: NaiveDateTime,
+    pub challenge: ChallengeInfo,
+    pub progress: ProgressInfo,
+}
+
+#[derive(Debug, Queryable, Serialize)]
+pub struct ChallengeInfo {
+    pub title: String,
+    pub description: String,
+    pub repo_url: String,
+    pub difficulty: String,
+    pub module_count: i32,
+    pub mode: String,
+    pub created_at: NaiveDateTime,
+    pub updated_at: NaiveDateTime,
+}
+
+#[derive(Debug, Queryable, Serialize)]
+pub struct ProgressInfo {
+    pub id: Uuid,
+    pub status: String,
+    pub progress_details: Option<serde_json::Value>,
+    pub created_at: NaiveDateTime,
     pub updated_at: NaiveDateTime,
 }

--- a/src/service/repository/repo.rs
+++ b/src/service/repository/repo.rs
@@ -6,7 +6,7 @@ use crate::shared::errors::{
     CreateRepositoryError, GetRepositoryError,
     RepositoryError::{FailedToCreateRepository, FailedToGetRepository},
 };
-use crate::shared::primitives::{PaginatedResponse, PaginationParams};
+use crate::shared::primitives::{PaginatedResponse, PaginationParams, Status};
 use anyhow::Result;
 use chrono::NaiveDateTime;
 use diesel::prelude::*;
@@ -135,6 +135,7 @@ impl Repository {
         user_id: &Uuid,
         repo_url: Option<&str>,
         soft_serve_url: Option<&str>,
+        status: Option<&Status>,
         pagination: &PaginationParams,
     ) -> Result<PaginatedResponse<RepositoryWithRelations>> {
         use crate::schema::{challenges, progress, repositories};
@@ -165,6 +166,10 @@ impl Repository {
 
         if let Some(url) = soft_serve_url {
             query = query.filter(repositories::soft_serve_url.eq(url));
+        }
+
+        if let Some(status) = status {
+            query = query.filter(progress::status.eq(status.to_str()));
         }
 
         let total: i64 = repositories::table

--- a/src/service/repository/repo.rs
+++ b/src/service/repository/repo.rs
@@ -1,10 +1,13 @@
 use crate::schema::repositories::table as repositories;
-use crate::service::database::models::Repository;
+use crate::service::database::models::{
+    ChallengeInfo, ProgressInfo, Repository, RepositoryWithRelations,
+};
 use crate::shared::errors::{
     CreateRepositoryError, GetRepositoryError,
     RepositoryError::{FailedToCreateRepository, FailedToGetRepository},
 };
 use anyhow::Result;
+use chrono::NaiveDateTime;
 use diesel::prelude::*;
 use log::error;
 use uuid::Uuid;
@@ -124,5 +127,144 @@ impl Repository {
             }
             _ => Err(anyhow::anyhow!("No input provided")),
         }
+    }
+
+    pub fn get_repo_with_relations(
+        connection: &mut PgConnection,
+        user_id: &Uuid,
+        repo_url: Option<&str>,
+        soft_serve_url: Option<&str>,
+    ) -> Result<Vec<RepositoryWithRelations>> {
+        use crate::schema::{challenges, progress, repositories};
+
+        if repo_url.is_some() && soft_serve_url.is_some() {
+            return Err(anyhow::anyhow!(
+                "Multiple parameters are not allowed. Please provide only one parameter."
+            ));
+        }
+
+        let mut query = repositories::table
+            .inner_join(challenges::table)
+            .inner_join(
+                progress::table.on(progress::user_id
+                    .eq(repositories::user_id)
+                    .and(progress::challenge_id.eq(repositories::challenge_id))),
+            )
+            .filter(repositories::user_id.eq(user_id))
+            .into_boxed();
+
+        if let Some(url) = repo_url {
+            query = query.filter(repositories::repo_url.eq(url));
+        }
+
+        if let Some(url) = soft_serve_url {
+            query = query.filter(repositories::soft_serve_url.eq(url));
+        }
+
+        let results = query
+            .select((
+                // Repository fields
+                repositories::id,
+                repositories::user_id,
+                repositories::challenge_id,
+                repositories::repo_url,
+                repositories::soft_serve_url,
+                repositories::created_at,
+                repositories::updated_at,
+                // Challenge fields as nested struct
+                (
+                    challenges::title,
+                    challenges::description,
+                    challenges::repo_url,
+                    challenges::difficulty,
+                    challenges::module_count,
+                    challenges::mode,
+                    challenges::created_at,
+                    challenges::updated_at,
+                ),
+                // Progress fields as nested struct
+                (
+                    progress::id,
+                    progress::status,
+                    progress::progress_details,
+                    progress::created_at,
+                    progress::updated_at,
+                ),
+            ))
+            .load::<(
+                Uuid,
+                Uuid,
+                Uuid,
+                String,
+                String,
+                NaiveDateTime,
+                NaiveDateTime,
+                (
+                    String,
+                    String,
+                    String,
+                    String,
+                    i32,
+                    String,
+                    NaiveDateTime,
+                    NaiveDateTime,
+                ),
+                (
+                    Uuid,
+                    String,
+                    Option<serde_json::Value>,
+                    NaiveDateTime,
+                    NaiveDateTime,
+                ),
+            )>(connection)
+            .map_err(|e| {
+                error!("Error getting repository with relations: {}", e);
+                anyhow::anyhow!("Failed to get repository with relations")
+            })?;
+
+        // Transform the raw results into our nested structure
+        Ok(results
+            .into_iter()
+            .map(
+                |(
+                    id,
+                    user_id,
+                    challenge_id,
+                    repo_url,
+                    soft_serve_url,
+                    created_at,
+                    updated_at,
+                    challenge_fields,
+                    progress_fields,
+                )| {
+                    RepositoryWithRelations {
+                        id,
+                        user_id,
+                        challenge_id,
+                        repo_url,
+                        soft_serve_url,
+                        created_at,
+                        updated_at,
+                        challenge: ChallengeInfo {
+                            title: challenge_fields.0,
+                            description: challenge_fields.1,
+                            repo_url: challenge_fields.2,
+                            difficulty: challenge_fields.3,
+                            module_count: challenge_fields.4,
+                            mode: challenge_fields.5,
+                            created_at: challenge_fields.6,
+                            updated_at: challenge_fields.7,
+                        },
+                        progress: ProgressInfo {
+                            id: progress_fields.0,
+                            status: progress_fields.1,
+                            progress_details: progress_fields.2,
+                            created_at: progress_fields.3,
+                            updated_at: progress_fields.4,
+                        },
+                    }
+                },
+            )
+            .collect::<Vec<RepositoryWithRelations>>())
     }
 }

--- a/src/shared/primitives.rs
+++ b/src/shared/primitives.rs
@@ -71,6 +71,7 @@ impl UserRole {
     }
 }
 
+#[derive(Debug, Serialize, Deserialize)]
 pub enum Status {
     Completed,
     InProgress,

--- a/src/shared/primitives.rs
+++ b/src/shared/primitives.rs
@@ -120,3 +120,18 @@ impl SubmissionStatus {
         }
     }
 }
+
+#[derive(Debug, Deserialize)]
+pub struct PaginationParams {
+    pub page: Option<i64>,
+    pub per_page: Option<i64>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct PaginatedResponse<T> {
+    pub data: Vec<T>,
+    pub total: i64,
+    pub page: i64,
+    pub per_page: i64,
+    pub total_pages: i64,
+}


### PR DESCRIPTION
This PR adds a get route to fetch user repositories. This is an authenticated route so the default is to return the user repository data in an array. The response is paginated per page.
The route accepts params such as:
1. repo_url
2. soft_serve_url
3. per_page
4. page

Below is a sample response object:

```json
{
    "data": [
        {
            "id": "73b227aa-f9df-40da-91e6-1d1c684e8d30",
            "user_id": "ac02c63b-ab39-4248-976f-1e2e415a8574",
            "challenge_id": "0d420322-7d8a-4fbd-9a78-6636da0f3ec5",
            "repo_url": "http://ss_5fbf467b554c93d19dbf338fe0dfebb77d103289@localhost:23232/extheo__hxckr-core.git",
            "soft_serve_url": "http://localhost:23232/extheo__hxckr-core.git",
            "created_at": "2024-10-18T12:03:16.007659",
            "updated_at": "2024-10-18T12:03:16.007662",
            "challenge": {
                "title": "bitcoin transactions",
                "description": "bitcoin transactions",
                "repo_url": "https://github.com/extheoisah/hxckr-core",
                "difficulty": "easy",
                "module_count": 1,
                "mode": "project",
                "created_at": "2024-08-27T17:44:39.757140",
                "updated_at": "2024-11-02T13:30:19.400109"
            },
            "progress": {
                "id": "c2c63e02-ebf6-4321-b766-83b947703210",
                "status": "not_started",
                "progress_details": {
                    "current_step": 1
                },
                "created_at": "2024-10-18T12:03:16.007668",
                "updated_at": "2024-10-18T12:03:16.007668"
            }
        },
        {
            "id": "53abeacf-6231-4c50-b043-a8008e641033",
            "user_id": "ac02c63b-ab39-4248-976f-1e2e415a8574",
            "challenge_id": "068fef8b-a6d6-4943-9e57-84bbf48a87d3",
            "repo_url": "http://ss_6f692472389f4364aeb63abc38c4b4e6b6081544@localhost:23232/extheo__hxckr-test-repo.git",
            "soft_serve_url": "http://localhost:23232/extheo__hxckr-test-repo.git",
            "created_at": "2024-11-02T15:02:27.718372",
            "updated_at": "2024-11-02T15:02:27.718379",
            "challenge": {
                "title": "hxckr test repo",
                "description": "hxckr test repo",
                "repo_url": "https://github.com/nully0x/hxckr-test-repo",
                "difficulty": "medium",
                "module_count": 3,
                "mode": "functional_test",
                "created_at": "2024-11-02T15:01:47.153293",
                "updated_at": "2024-11-02T16:33:37.094172"
            },
            "progress": {
                "id": "b5fe49e4-df70-487e-a397-72b1c478892e",
                "status": "in_progress",
                "progress_details": {
                    "current_step": 1
                },
                "created_at": "2024-11-02T15:02:27.718398",
                "updated_at": "2024-11-03T23:31:17.023273"
            }
        },
        {
            "id": "5b0fc38c-b67f-4e39-a0d0-f40a6cbcd6dc",
            "user_id": "ac02c63b-ab39-4248-976f-1e2e415a8574",
            "challenge_id": "f910c56c-eeb6-4a61-aa69-b23e28cc20ef",
            "repo_url": "http://ss_27151691c873f7db4323fb436a5f44056cd512db@localhost:23232/extheo__workshop-broken-musig-wallet-debugging--ts.git",
            "soft_serve_url": "http://localhost:23232/extheo__workshop-broken-musig-wallet-debugging--ts.git",
            "created_at": "2024-11-05T16:12:40.432565",
            "updated_at": "2024-11-05T16:12:40.432569",
            "challenge": {
                "title": "hxckr demo test repo",
                "description": "hxckr demo test repo",
                "repo_url": "https://github.com/hxckr-org/workshop-broken-musig-wallet-debugging--ts",
                "difficulty": "medium",
                "module_count": 2,
                "mode": "functional_test",
                "created_at": "2024-11-05T16:12:19.839262",
                "updated_at": "2024-11-05T16:12:19.839265"
            },
            "progress": {
                "id": "b0b5ed2c-658d-438b-a6a1-47c5b18885f0",
                "status": "in_progress",
                "progress_details": {
                    "current_step": 2
                },
                "created_at": "2024-11-05T16:12:40.432590",
                "updated_at": "2024-11-05T16:16:30.303778"
            }
        }
    ],
    "total": 3,
    "page": 1,
    "per_page": 10,
    "total_pages": 1
}
```