### PR TITLE
chore(feat): impl. delete challenge endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 diesel.toml
 .env
 /soft_serve_postgres_data
+.npm-global

--- a/README.md
+++ b/README.md
@@ -135,6 +135,8 @@ The workflow will build and push a new Docker image on each push to the main bra
 
 ## Development
 
+> Please refer to the [CONTRIBUTING.md](CONTRIBUTING.md) file for more details on how to contribute to this project.
+
 ### Spell Checking
 
 To maintain consistent spelling across the project, we use the [`typos crate`](https://github.com/crate-ci/typos) for spell checking. Follow these steps to run the spell check locally:

--- a/src/service/repository/challenge.rs
+++ b/src/service/repository/challenge.rs
@@ -140,12 +140,11 @@ impl Challenge {
                 FailedToGetChallenge(GetChallengeError(e)).into()
             })
     }
-
-    pub fn delete(connection: &mut PgConnection, challenge_id: &Uuid) -> Result<usize> {
+    pub fn delete(connection: &mut PgConnection, challenge_id: &Uuid) -> Result<()> {
         use crate::schema::challenges::dsl::id;
 
         match diesel::delete(challenges_table.filter(id.eq(challenge_id))).execute(connection) {
-            Ok(count) => Ok(count),
+            Ok(_) => Ok(()),
             Err(e) => {
                 error!("Error deleting challenge: {}", e);
                 Err(FailedToDeleteChallenge(DeleteChallengeError(e)).into())

--- a/src/service/repository/challenge.rs
+++ b/src/service/repository/challenge.rs
@@ -1,10 +1,10 @@
 use crate::schema::challenges::table as challenges_table;
 use crate::service::database::models::Challenge;
-use crate::shared::errors::GetChallengeError;
 use crate::shared::errors::{
     CreateChallengeError,
-    RepositoryError::{FailedToCreateChallenge, FailedToGetChallenge},
+    RepositoryError::{FailedToCreateChallenge, FailedToDeleteChallenge, FailedToGetChallenge},
 };
+use crate::shared::errors::{DeleteChallengeError, GetChallengeError};
 use crate::shared::primitives::{ChallengeMode, Difficulty};
 use anyhow::Result;
 use diesel::prelude::*;
@@ -139,5 +139,17 @@ impl Challenge {
                 error!("Error getting challenges: {}", e);
                 FailedToGetChallenge(GetChallengeError(e)).into()
             })
+    }
+
+    pub fn delete(connection: &mut PgConnection, challenge_id: &Uuid) -> Result<usize> {
+        use crate::schema::challenges::dsl::id;
+
+        match diesel::delete(challenges_table.filter(id.eq(challenge_id))).execute(connection) {
+            Ok(count) => Ok(count),
+            Err(e) => {
+                error!("Error deleting challenge: {}", e);
+                Err(FailedToDeleteChallenge(DeleteChallengeError(e)).into())
+            }
+        }
     }
 }

--- a/src/shared/errors.rs
+++ b/src/shared/errors.rs
@@ -58,6 +58,8 @@ pub enum RepositoryError {
     FailedToCreateUserBadge(#[from] CreateUserBadgeError),
     #[error("Failed to get user badge")]
     FailedToGetUserBadge(#[from] GetUserBadgeError),
+    #[error("Failed to delete challenge")]
+    FailedToDeleteChallenge(#[from] DeleteChallengeError),
 }
 
 impl From<diesel::result::Error> for RepositoryError {
@@ -166,3 +168,7 @@ pub struct CreateUserBadgeError(#[from] pub diesel::result::Error);
 #[derive(Error, Debug)]
 #[error("Database error while getting user badge: {0}")]
 pub struct GetUserBadgeError(#[from] pub diesel::result::Error);
+
+#[derive(Error, Debug)]
+#[error("Database error while deleting challenge: {0}")]
+pub struct DeleteChallengeError(#[from] pub diesel::result::Error);


### PR DESCRIPTION
This PR implements DELETE endpoint that allows administrators to remove challenges from the platform.

## Changes
- Added DELETE endpoint `/api/challenge?id={uuid}`
- Added challenge deletion functionality to Challenge model
- Added new error types for delete operations
- Implemented admin-only authorization check

## API Usage
```http
DELETE /api/challenge/delete?id=550e8400-e29b-41d4-a716-446655440000
x-session-token: hxckr_your_session_token
```

## Response
Success (200):
```json
{
    "status": "success",
    "message": "Challenge deleted successfully"
}
```

## Checks
- Requires valid session token
- Limited to admin users only
- Validates challenge existence before deletion

## Testing
- [ x] Verify admin-only access
- [x ] Verify successful challenge deletion
- [ x] Verify error handling for non-existent challenges
- [x ] Verify unauthorized access handling